### PR TITLE
Remove apikey from query

### DIFF
--- a/source/includes/transports/_overview.md
+++ b/source/includes/transports/_overview.md
@@ -4,18 +4,12 @@
 
 The base URL for Simplex API's is:
 
-`https://api.simplexcc.com/v1`
+`https://api.simplexcc.com/v3`
 
 ## Authentication ##
 
-All API's must be authenticated. To authenticate, supply your API key as the value of either the `_apikey` query parameter or the `Authorization` HTTP header with the `apikey` authorization scheme.
+All API's must be authenticated. To authenticate, supply your API key as the `Authorization` HTTP header with the `apikey` authorization scheme.
 
-> Example authentication using a query parameter:
-
-```bash
-curl \
-  'https://api.simplexcc.com/v3/get-quote?_apikey=8d20e7bd89064cd4a9c379d66c53efc8&...'
-```
 
 > Example authentication using an HTTP header:
 

--- a/source/includes/transports/_prest.md
+++ b/source/includes/transports/_prest.md
@@ -10,13 +10,14 @@ Simplex will only ever make HTTPS requests, never HTTP.
 
 ## Authentication ##
 
-You provide Simplex with a p/REST API key of your own, which Simplex will include as the query parameter `"_apikey"` in all p/REST API calls it makes.
+You provide Simplex with a p/REST API key of your own, which Simplex will include as the `Authorization` HTTP header with the `apikey` authorization scheme in all p/REST API calls it makes.
 
 > Example authentication in p/REST:
 
 ```bash
 curl \
-  'https://${YOUR_API_URL}/send-coins?_apikey=f16b16926976411a8917de3f50c825a4&...'
+  -H 'Authorization: apikey 8d20e7bd89064cd4a9c379d66c53efc8' \
+  'https://${YOUR_API_URL}/send-coins'
 ```
 
 ## Parameters ##


### PR DESCRIPTION
Removed URL APIKEY entries, updated to header Authentication, updated base url from "v1" to "v3"
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->